### PR TITLE
feat: GitHubのIssueと連携したロードマップを公開する (close #42)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -205,3 +205,19 @@ body {
 :root[data-time="night"] {
 	--background: oklch(0.99 0.012 250);
 }
+
+/*
+---break--- */
+/*
+	ロードマップの進捗バー（issue #42）。0 から実際の割合まで伸ばす。
+	伸ばす先は width の値そのものではなく --roadmap-progress で受け取る。
+	要素側の width はアニメーション終了後の値として残す必要があるため。
+*/
+@keyframes roadmap-progress-grow {
+	from {
+		width: 0;
+	}
+	to {
+		width: var(--roadmap-progress);
+	}
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,19 +1,30 @@
-import React, { Suspense } from "react";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/shadcnui/avatar";
 import { Scene } from "@/components/3d/Scene";
 import { FadeInContainer } from "@/components/ui/FadeInContainer";
 import { OgpCard } from "@/components/ui/OgpCard";
+import { RoadmapCard } from "@/components/ui/RoadmapCard";
 import { SocialLinkIcon } from "@/components/ui/SocialLinkIcon";
 import { StyledLink } from "@/components/ui/StyledLink";
 import { Text } from "@/components/ui/Text";
 import { WorkCard } from "@/components/ui/WorkCard";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/shadcnui/avatar";
+import { filterByStatus, getRoadmapItems } from "@/lib/roadmap";
 import { socialLinks } from "@/lib/socialLinks";
 import { getAllWorks } from "@/lib/works";
 import { getAllArticleOgps } from "@/lib/zenn";
+import React, { Suspense } from "react";
+
+/** トップに出すロードマップの件数 */
+const ROADMAP_PREVIEW_COUNT = 3;
 
 export default async function HomePage() {
 	const ogps = await getAllArticleOgps();
 	const works = await getAllWorks();
+	const allRoadmapItems = await getRoadmapItems();
+	// トップでは「これから」だけ見せる。できたことは制作物やロードマップ側で見てもらう。
+	const roadmapItems = [
+		...filterByStatus(allRoadmapItems, "wip"),
+		...filterByStatus(allRoadmapItems, "todo"),
+	].slice(0, ROADMAP_PREVIEW_COUNT);
 	return (
 		<>
 			{/* トップ */}
@@ -136,6 +147,35 @@ export default async function HomePage() {
 							</StyledLink>
 						</Text>
 					</section>
+
+					{/* ロードマップ */}
+					{roadmapItems.length > 0 && (
+						<section className=" my-16 ">
+							<Text variant="h2">ロードマップ</Text>
+							<Text variant="small" className=" mt-2 ">
+								このサイトにこれから盛り込みたいことです。
+							</Text>
+							<FadeInContainer
+								className="
+									grid gap-6 mt-8 mb-4 items-stretch
+									[grid-template-columns:repeat(auto-fill,minmax(200px,1fr))]
+									sm:[grid-template-columns:repeat(auto-fill,minmax(220px,1fr))]
+									md:[grid-template-columns:repeat(auto-fill,minmax(240px,1fr))]
+									lg:[grid-template-columns:repeat(auto-fill,minmax(280px,1fr))]
+									[&>div]:h-full
+								"
+							>
+								{roadmapItems.map((item) => (
+									<RoadmapCard key={item.number} item={item} />
+								))}
+							</FadeInContainer>
+							<Text variant="p" className=" text-sm text-maki-gray text-right ">
+								<StyledLink href="/roadmap">
+									<u>ロードマップを見る</u>→
+								</StyledLink>
+							</Text>
+						</section>
+					)}
 
 					{/* コンタクト */}
 					<section className=" my-16 ">

--- a/src/app/roadmap/page.tsx
+++ b/src/app/roadmap/page.tsx
@@ -1,0 +1,123 @@
+import { FadeInContainer } from "@/components/ui/FadeInContainer";
+import { RoadmapCard } from "@/components/ui/RoadmapCard";
+import { RoadmapProgress } from "@/components/ui/RoadmapProgress";
+import { Text } from "@/components/ui/Text";
+import { type RoadmapStatus, filterByStatus, getRoadmapItems } from "@/lib/roadmap";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+	title: "ロードマップ | まきむらのポートフォリオ",
+	description: "このサイトにこれから盛り込みたい機能と、できたことの記録です。",
+};
+
+const ISSUES_URL = "https://github.com/makim0939/portfolio/issues";
+
+const sections: { status: RoadmapStatus; heading: string; lead: string; empty: string }[] = [
+	{
+		status: "wip",
+		heading: "いま作ってる",
+		lead: "手を動かしている最中のものです。",
+		empty: "いまは手が空いています。次は何を作ろう。",
+	},
+	{
+		status: "todo",
+		heading: "作りたい",
+		lead: "いつか形にしたいことたち。順番は決めていません。",
+		empty: "やりたいことを書き出し中です。",
+	},
+	{
+		status: "done",
+		heading: "できた",
+		lead: "このサイトに入った機能です。",
+		empty: "まだありません。",
+	},
+];
+
+export default async function RoadmapPage() {
+	const items = await getRoadmapItems();
+	const doneCount = filterByStatus(items, "done").length;
+
+	return (
+		<main className=" min-h-[75vh] lg:max-w-6xl lg:m-auto ">
+			<header>
+				<Text variant="h1">ロードマップ</Text>
+				<Text className=" mt-6 ">
+					このサイトにこれから盛り込みたいことを、そのまま公開しています。
+					<br />
+					中身は GitHub の Issue で、カードを押すと元の Issue に飛びます。
+				</Text>
+				<div className=" mt-8 ">
+					<RoadmapProgress done={doneCount} total={items.length} />
+				</div>
+			</header>
+			<hr className="my-8" />
+
+			{/* 3つの節を1本の線でつなぎ、上から下へ進んでいく道に見せる */}
+			<div className=" relative ">
+				<div className=" absolute left-[5px] top-3 bottom-3 border-l-2 border-dashed border-neutral-300 " />
+				<ol className=" space-y-16 ">
+					{sections.map((section) => {
+						const sectionItems = filterByStatus(items, section.status);
+						return (
+							// 節ごとに直接リンクできるよう id を振る（/roadmap#todo など）
+							<li id={section.status} key={section.status} className=" relative pl-8 md:pl-10 ">
+								<span
+									aria-hidden="true"
+									className={` absolute left-0 top-2.5 w-3 h-3 rounded-full ${
+										section.status === "wip"
+											? "bg-amber-400"
+											: section.status === "done"
+												? "bg-emerald-400"
+												: "bg-neutral-300"
+									} `}
+								/>
+								<hgroup className=" mb-6 ">
+									<Text variant="h2" className=" text-xl md:text-2xl ">
+										{section.heading}
+										<span className=" ml-3 text-sm font-normal text-maki-gray tabular-nums ">
+											{sectionItems.length}
+										</span>
+									</Text>
+									<Text variant="small" className=" mt-1 ">
+										{section.lead}
+									</Text>
+								</hgroup>
+
+								{sectionItems.length === 0 ? (
+									<Text variant="small" className=" text-maki-gray ">
+										{section.empty}
+									</Text>
+								) : (
+									<FadeInContainer
+										className="
+											grid gap-4 md:gap-6 items-stretch
+											[grid-template-columns:repeat(auto-fill,minmax(220px,1fr))]
+											md:[grid-template-columns:repeat(auto-fill,minmax(260px,1fr))]
+											lg:[grid-template-columns:repeat(auto-fill,minmax(300px,1fr))]
+											[&>div]:h-full
+										"
+									>
+										{sectionItems.map((item) => (
+											<RoadmapCard key={item.number} item={item} />
+										))}
+									</FadeInContainer>
+								)}
+							</li>
+						);
+					})}
+				</ol>
+			</div>
+
+			<Text variant="p" className=" mt-16 text-sm text-maki-gray text-right ">
+				<a
+					href={ISSUES_URL}
+					target="_blank"
+					rel="noopener noreferrer"
+					className=" hover:text-blue-500 duration-100 "
+				>
+					<u>GitHubで全てのIssueを見る</u>→
+				</a>
+			</Text>
+		</main>
+	);
+}

--- a/src/components/ui/RoadmapCard.stories.tsx
+++ b/src/components/ui/RoadmapCard.stories.tsx
@@ -8,28 +8,56 @@ const meta: Meta<typeof RoadmapCard> = {
 export default meta;
 type Story = StoryObj<typeof RoadmapCard>;
 
-export const Wip: Story = {
+/** 文だけの Issue */
+export const Todo: Story = {
 	args: {
 		item: {
 			number: 42,
 			title: "Issueと連携した制作ロードマップの公開",
-			description: "Webサイトの中で、今後盛り込みたい機能をワクワクするUIで公開する。",
-			status: "wip",
+			summary: "Webサイトの中で、今後盛り込みたい機能をワクワクするUIで公開する。",
+			items: [],
+			status: "todo",
 			url: "https://github.com/makim0939/portfolio/issues/42",
-			createdAt: "2025-08-09",
+			createdAt: "2026-08-09",
 		},
 	},
 };
 
-export const Todo: Story = {
+/** チェックボックス付きの箇条書きを持つ Issue */
+export const WipWithChecklist: Story = {
 	args: {
 		item: {
-			number: 41,
-			title: "3DCGの部屋の出現アニメーション",
-			description: "オブジェクトごとにアニメーションをつけるため、glbを分割する。",
+			number: 36,
+			title: "キャラクターに「手を振る」以外のモーションを作成する",
+			summary: "追加するモーション",
+			items: [
+				{ text: "PC作業をする", done: true },
+				{ text: "ギター／ピアノを弾く", done: false },
+				{ text: "寝る", done: false },
+			],
+			status: "wip",
+			url: "https://github.com/makim0939/portfolio/issues/36",
+			createdAt: "2026-08-08",
+		},
+	},
+};
+
+/** 件数が多く、「ほか N 件」にまとまる Issue */
+export const TodoWithManyBullets: Story = {
+	args: {
+		item: {
+			number: 43,
+			title: "キャラクターモーションの遷移",
+			summary: "複数のキャラクターモーションが切り替わるようにする。 候補は以下。",
+			items: [
+				{ text: "インテリアクリックで切り替え。（ユーザが切り替え）" },
+				{ text: "時間帯で切り替え。（システムが切り替え）" },
+				{ text: "ページ読み込み時にランダムで切り替え。（システムが切り替え）" },
+				{ text: "GithubのStatus連携で切り替え。（開発者が切り替え）" },
+			],
 			status: "todo",
-			url: "https://github.com/makim0939/portfolio/issues/41",
-			createdAt: "2025-08-09",
+			url: "https://github.com/makim0939/portfolio/issues/43",
+			createdAt: "2026-08-09",
 		},
 	},
 };
@@ -39,12 +67,16 @@ export const Done: Story = {
 		item: {
 			number: 35,
 			title: "時間帯に応じて背景色と光の色をリアルタイムに更新する",
-			description:
-				"光の色と角度の更新の実現方法は以下のどちらでも良い。背景色はシームレスに変わると見にくいため、パターンを用意して切り替える。",
+			summary:
+				"光の色と角度の更新の実現方法は以下のどちらでも良い。 背景色はシームレスに変わると見にくいため、パターンを用意して切り替える。",
+			items: [
+				{ text: "時間から計算してシームレスに変更する。" },
+				{ text: "朝、昼、夜などのパターンを用意して切り替える。" },
+			],
 			status: "done",
 			url: "https://github.com/makim0939/portfolio/issues/35",
-			createdAt: "2025-08-08",
-			completedAt: "2025-08-09",
+			createdAt: "2026-08-08",
+			completedAt: "2026-08-09",
 		},
 	},
 };

--- a/src/components/ui/RoadmapCard.stories.tsx
+++ b/src/components/ui/RoadmapCard.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import { RoadmapCard } from "./RoadmapCard";
+
+const meta: Meta<typeof RoadmapCard> = {
+	component: RoadmapCard,
+};
+
+export default meta;
+type Story = StoryObj<typeof RoadmapCard>;
+
+export const Wip: Story = {
+	args: {
+		item: {
+			number: 42,
+			title: "Issueと連携した制作ロードマップの公開",
+			description: "Webサイトの中で、今後盛り込みたい機能をワクワクするUIで公開する。",
+			status: "wip",
+			url: "https://github.com/makim0939/portfolio/issues/42",
+			createdAt: "2025-08-09",
+		},
+	},
+};
+
+export const Todo: Story = {
+	args: {
+		item: {
+			number: 41,
+			title: "3DCGの部屋の出現アニメーション",
+			description: "オブジェクトごとにアニメーションをつけるため、glbを分割する。",
+			status: "todo",
+			url: "https://github.com/makim0939/portfolio/issues/41",
+			createdAt: "2025-08-09",
+		},
+	},
+};
+
+export const Done: Story = {
+	args: {
+		item: {
+			number: 35,
+			title: "時間帯に応じて背景色と光の色をリアルタイムに更新する",
+			description:
+				"光の色と角度の更新の実現方法は以下のどちらでも良い。背景色はシームレスに変わると見にくいため、パターンを用意して切り替える。",
+			status: "done",
+			url: "https://github.com/makim0939/portfolio/issues/35",
+			createdAt: "2025-08-08",
+			completedAt: "2025-08-09",
+		},
+	},
+};

--- a/src/components/ui/RoadmapCard.tsx
+++ b/src/components/ui/RoadmapCard.tsx
@@ -1,0 +1,107 @@
+import type { RoadmapItem, RoadmapStatus } from "@/lib/roadmap";
+import { tv } from "tailwind-variants";
+
+// 状態は色だけでなく、面の作り（実線か破線か）と印（●／✓）でも区別する。
+// 色だけだと時間帯で背景色が変わったときに差が読み取りにくいため。
+const card = tv({
+	base: " group relative flex flex-col gap-2 h-full p-5 rounded-2xl bg-[var(--surface)] transition duration-200 hover:-translate-y-1 ",
+	variants: {
+		status: {
+			wip: " border-2 border-amber-300 shadow-lg hover:shadow-xl ",
+			todo: " border-2 border-dashed border-neutral-300 shadow-sm hover:shadow-lg ",
+			done: " border-2 border-neutral-100 shadow-sm hover:shadow-md opacity-80 hover:opacity-100 ",
+		},
+	},
+});
+
+const badge = tv({
+	base: " inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[11px] tracking-[0.08em] ",
+	variants: {
+		status: {
+			wip: " bg-amber-100 text-amber-800 ",
+			todo: " bg-neutral-100 text-maki-gray ",
+			done: " bg-emerald-100 text-emerald-800 ",
+		},
+	},
+});
+
+const statusLabel: Record<RoadmapStatus, string> = {
+	wip: "いま作ってる",
+	todo: "作りたい",
+	done: "できた",
+};
+
+function StatusMark({ status }: { status: RoadmapStatus }) {
+	if (status === "done") {
+		return (
+			<svg viewBox="0 0 12 12" width="10" height="10" role="img" aria-label="完了">
+				<path
+					d="M1.5 6.5 L4.5 9.5 L10.5 2.5"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="2"
+					strokeLinecap="round"
+					strokeLinejoin="round"
+				/>
+			</svg>
+		);
+	}
+	// 制作中だけ、点が脈打って「動いている」ことを見せる。
+	return (
+		<span className=" relative flex w-2 h-2 ">
+			{status === "wip" && (
+				<span className=" absolute inline-flex w-full h-full rounded-full bg-amber-400 opacity-75 animate-ping " />
+			)}
+			<span
+				className={`relative inline-flex w-2 h-2 rounded-full ${
+					status === "wip" ? "bg-amber-500" : "bg-neutral-400"
+				}`}
+			/>
+		</span>
+	);
+}
+
+export function RoadmapCard({ item }: { item: RoadmapItem }) {
+	const date = item.status === "done" ? item.completedAt : item.createdAt;
+
+	return (
+		<article className={card({ status: item.status })}>
+			<div className=" flex items-center justify-between gap-2 ">
+				<span className={badge({ status: item.status })}>
+					<StatusMark status={item.status} />
+					{statusLabel[item.status]}
+				</span>
+				{date && (
+					<time dateTime={date} className=" text-[11px] text-maki-gray ">
+						{date}
+					</time>
+				)}
+			</div>
+
+			{/* カード全体をリンクにする。中に他のリンクを置かないので、擬似要素で面を覆う */}
+			<h3 className=" text-base font-semibold leading-relaxed ">
+				<a
+					href={item.url}
+					target="_blank"
+					rel="noopener noreferrer"
+					className=" before:absolute before:inset-0 before:rounded-2xl group-hover:text-blue-600 transition-colors "
+				>
+					{item.title}
+				</a>
+			</h3>
+
+			{item.description && (
+				<p className=" text-sm text-neutral-600 leading-relaxed line-clamp-3 ">
+					{item.description}
+				</p>
+			)}
+
+			<p className=" mt-auto pt-2 text-[11px] text-maki-gray ">
+				Issue #{item.number}
+				<span className=" ml-1 inline-block transition-transform group-hover:translate-x-1 ">
+					→
+				</span>
+			</p>
+		</article>
+	);
+}

--- a/src/components/ui/RoadmapCard.tsx
+++ b/src/components/ui/RoadmapCard.tsx
@@ -1,5 +1,8 @@
-import type { RoadmapItem, RoadmapStatus } from "@/lib/roadmap";
+import type { RoadmapItem, RoadmapListItem, RoadmapStatus } from "@/lib/roadmap";
 import { tv } from "tailwind-variants";
+
+/** カードに出す箇条書きの件数。これを超えた分は「ほか N 件」にまとめる */
+const MAX_LIST_ITEMS = 3;
 
 // 状態は色だけでなく、面の作り（実線か破線か）と印（●／✓）でも区別する。
 // 色だけだと時間帯で背景色が変わったときに差が読み取りにくいため。
@@ -61,6 +64,60 @@ function StatusMark({ status }: { status: RoadmapStatus }) {
 	);
 }
 
+/**
+ * 箇条書きの行頭の印。チェックボックス付きなら済／未が分かる形にし、
+ * ただの箇条書きなら中黒を置く。
+ */
+function ListMark({ done }: { done?: boolean }) {
+	if (done === undefined) {
+		return <span className=" mt-2 w-1 h-1 shrink-0 rounded-full bg-neutral-400 " />;
+	}
+	return (
+		<span
+			className={` mt-0.5 grid place-items-center w-3.5 h-3.5 shrink-0 rounded border ${
+				done ? "bg-emerald-500 border-emerald-500 text-white" : "border-neutral-300"
+			} `}
+		>
+			{done && (
+				<svg viewBox="0 0 12 12" width="9" height="9" role="img" aria-label="完了">
+					<path
+						d="M2 6.5 L4.8 9 L10 3"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="2"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+					/>
+				</svg>
+			)}
+		</span>
+	);
+}
+
+function ListItems({ items }: { items: RoadmapListItem[] }) {
+	const shown = items.slice(0, MAX_LIST_ITEMS);
+	const rest = items.length - shown.length;
+	// 「ほか N 件」の字下げは行頭の印の幅に合わせる（中黒とチェックボックスで幅が違う）
+	const restIndent = shown.some((listItem) => listItem.done !== undefined) ? "pl-[22px]" : "pl-3";
+
+	return (
+		<ul className=" space-y-1 text-sm text-neutral-600 ">
+			{shown.map((listItem) => (
+				<li key={listItem.text} className=" flex items-start gap-2 ">
+					<ListMark done={listItem.done} />
+					{/* 1件が長くても2行で止める。3件×2行がカードの取りうる最大 */}
+					<span
+						className={` line-clamp-2 ${listItem.done ? "text-neutral-400 line-through" : ""} `}
+					>
+						{listItem.text}
+					</span>
+				</li>
+			))}
+			{rest > 0 && <li className={` ${restIndent} text-[11px] text-maki-gray `}>ほか {rest} 件</li>}
+		</ul>
+	);
+}
+
 export function RoadmapCard({ item }: { item: RoadmapItem }) {
 	const date = item.status === "done" ? item.completedAt : item.createdAt;
 
@@ -90,11 +147,18 @@ export function RoadmapCard({ item }: { item: RoadmapItem }) {
 				</a>
 			</h3>
 
-			{item.description && (
-				<p className=" text-sm text-neutral-600 leading-relaxed line-clamp-3 ">
-					{item.description}
+			{item.summary && (
+				<p
+					className={` text-sm text-neutral-600 leading-relaxed ${
+						// 箇条書きが続くときは文を2行に抑えて、リストの居場所を空ける
+						item.items.length > 0 ? "line-clamp-2" : "line-clamp-3"
+					} `}
+				>
+					{item.summary}
 				</p>
 			)}
+
+			{item.items.length > 0 && <ListItems items={item.items} />}
 
 			<p className=" mt-auto pt-2 text-[11px] text-maki-gray ">
 				Issue #{item.number}

--- a/src/components/ui/RoadmapProgress.stories.tsx
+++ b/src/components/ui/RoadmapProgress.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import { RoadmapProgress } from "./RoadmapProgress";
+
+const meta: Meta<typeof RoadmapProgress> = {
+	component: RoadmapProgress,
+};
+
+export default meta;
+type Story = StoryObj<typeof RoadmapProgress>;
+
+export const Default: Story = {
+	args: { done: 3, total: 8 },
+};
+
+export const Empty: Story = {
+	args: { done: 0, total: 0 },
+};
+
+export const Completed: Story = {
+	args: { done: 5, total: 5 },
+};

--- a/src/components/ui/RoadmapProgress.tsx
+++ b/src/components/ui/RoadmapProgress.tsx
@@ -1,0 +1,33 @@
+import type { CSSProperties } from "react";
+
+type RoadmapProgressProps = {
+	done: number;
+	total: number;
+};
+
+/**
+ * 「これまでにどれだけ進んだか」を1本のバーで見せる。
+ * バーは 0 から実際の割合まで伸びる（アニメーションは globals.css の
+ * roadmap-progress-grow）。JS を持たせたくないので、幅は CSS 変数で渡している。
+ */
+export function RoadmapProgress({ done, total }: RoadmapProgressProps) {
+	const percent = total === 0 ? 0 : Math.round((done / total) * 100);
+
+	return (
+		<div className=" w-full max-w-md ">
+			<div className=" flex items-baseline justify-between mb-2 ">
+				<p className=" text-sm text-maki-gray tracking-[0.06em] ">
+					できたこと <span className=" text-maki-black font-semibold ">{done}</span> / {total}
+				</p>
+				<p className=" text-sm text-maki-gray tabular-nums ">{percent}%</p>
+			</div>
+			{/* 件数と割合は上のテキストで読めるので、バーは飾りとして読み上げから外す */}
+			<div aria-hidden="true" className=" h-2 w-full rounded-full bg-neutral-200 overflow-hidden ">
+				<div
+					className=" h-full rounded-full bg-gradient-to-r from-emerald-400 to-amber-300 animate-[roadmap-progress-grow_1.2s_ease-out] "
+					style={{ "--roadmap-progress": `${percent}%`, width: `${percent}%` } as CSSProperties}
+				/>
+			</div>
+		</div>
+	);
+}

--- a/src/lib/roadmap.ts
+++ b/src/lib/roadmap.ts
@@ -1,0 +1,118 @@
+// GitHub の Issue をそのままロードマップの元データとして使う（issue #42）。
+// サイト側に別途ロードマップの一覧を持つと Issue と二重管理になって必ずずれるので、
+// 公開する内容は enhancement ラベルの付いた Issue に一本化している。
+
+export type RoadmapStatus = "wip" | "todo" | "done";
+
+export type RoadmapItem = {
+	number: number;
+	title: string;
+	/** Issue 本文。カードでは先頭だけ抜粋して使う */
+	description: string;
+	status: RoadmapStatus;
+	url: string;
+	/** YYYY-MM-DD */
+	createdAt: string;
+	/** YYYY-MM-DD。done のときだけ入る */
+	completedAt?: string;
+};
+
+type GitHubIssue = {
+	number: number;
+	title: string;
+	body: string | null;
+	state: "open" | "closed";
+	html_url: string;
+	created_at: string;
+	closed_at: string | null;
+	assignees: { login: string }[];
+	/** Issues API は PR も返す。PR にだけこのキーが付く */
+	pull_request?: unknown;
+};
+
+const OWNER = "makim0939";
+const REPO = "portfolio";
+const LABEL = "enhancement";
+
+/** カードの抜粋に使う本文の長さ */
+const DESCRIPTION_LENGTH = 120;
+
+function formatDate(iso: string): string {
+	const date = new Date(iso);
+	const yyyy = date.getFullYear();
+	const mm = (date.getMonth() + 1).toString().padStart(2, "0");
+	const dd = date.getDate().toString().padStart(2, "0");
+	return `${yyyy}-${mm}-${dd}`;
+}
+
+/**
+ * Issue 本文はマークダウンなので、記号を落としてカード用の一文にする。
+ * 見出しやリストの記号がそのまま出ると読めないため。
+ */
+function toDescription(body: string | null): string {
+	if (!body) return "";
+	const plain = body
+		.replace(/```[\s\S]*?```/g, "") // コードブロックごと落とす
+		.replace(/^#+\s*/gm, "")
+		.replace(/^[-*]\s*/gm, "")
+		.replace(/!?\[([^\]]*)\]\([^)]*\)/g, "$1") // リンク・画像はテキストだけ残す
+		.replace(/[*_`>|]/g, "")
+		.replace(/\s+/g, " ")
+		.trim();
+	return plain.length > DESCRIPTION_LENGTH ? `${plain.slice(0, DESCRIPTION_LENGTH)}…` : plain;
+}
+
+/**
+ * open な Issue のうち、担当者が付いているものを「制作中」とみなす。
+ * 着手を表す情報が Issue 側に他にないため、アサインを着手の合図として使っている。
+ * （自分にアサインすればサイト上で「いま作っているもの」に上がる）
+ */
+function toStatus(issue: GitHubIssue): RoadmapStatus {
+	if (issue.state === "closed") return "done";
+	return issue.assignees.length > 0 ? "wip" : "todo";
+}
+
+export async function getRoadmapItems(): Promise<RoadmapItem[]> {
+	const url = `https://api.github.com/repos/${OWNER}/${REPO}/issues?state=all&labels=${LABEL}&per_page=100&sort=created&direction=desc`;
+
+	// 公開リポジトリなので認証なしでも読めるが、その場合 IP あたり 60req/h に制限される。
+	// トークンがある環境では使い、無い環境（ローカルなど）でも動くようにしている。
+	const token = process.env.GITHUB_TOKEN;
+
+	try {
+		const res = await fetch(url, {
+			headers: {
+				Accept: "application/vnd.github+json",
+				...(token ? { Authorization: `Bearer ${token}` } : {}),
+			},
+			next: { revalidate: 3600 }, // ISRでキャッシュ
+		});
+		if (!res.ok) throw new Error(`Failed to fetch issues: ${res.status}`);
+
+		const issues: GitHubIssue[] = await res.json();
+
+		return issues
+			.filter((issue) => !issue.pull_request) // Issues API が混ぜてくる PR を除く
+			.map((issue) => ({
+				number: issue.number,
+				title: issue.title,
+				description: toDescription(issue.body),
+				status: toStatus(issue),
+				url: issue.html_url,
+				createdAt: formatDate(issue.created_at),
+				completedAt: issue.closed_at ? formatDate(issue.closed_at) : undefined,
+			}));
+	} catch (e) {
+		// ロードマップはサイトの主役ではないので、取得に失敗してもページごと落とさず
+		// 空の状態で表示する。
+		console.error("Failed to fetch roadmap items:", e);
+		return [];
+	}
+}
+
+export function filterByStatus(items: RoadmapItem[], status: RoadmapStatus): RoadmapItem[] {
+	const filtered = items.filter((item) => item.status === status);
+	// done は完了が新しい順、それ以外は Issue が新しい順（API の並びのまま）
+	if (status !== "done") return filtered;
+	return filtered.sort((a, b) => ((a.completedAt ?? "") < (b.completedAt ?? "") ? 1 : -1));
+}

--- a/src/lib/roadmap.ts
+++ b/src/lib/roadmap.ts
@@ -4,11 +4,19 @@
 
 export type RoadmapStatus = "wip" | "todo" | "done";
 
+/** Issue 本文の箇条書き1行。done はチェックボックス付きのときだけ入る */
+export type RoadmapListItem = {
+	text: string;
+	done?: boolean;
+};
+
 export type RoadmapItem = {
 	number: number;
 	title: string;
-	/** Issue 本文。カードでは先頭だけ抜粋して使う */
-	description: string;
+	/** Issue 本文のうち、箇条書きが始まる前の文 */
+	summary: string;
+	/** Issue 本文の箇条書き。カードでは先頭数件だけ出す */
+	items: RoadmapListItem[];
 	status: RoadmapStatus;
 	url: string;
 	/** YYYY-MM-DD */
@@ -34,8 +42,8 @@ const OWNER = "makim0939";
 const REPO = "portfolio";
 const LABEL = "enhancement";
 
-/** カードの抜粋に使う本文の長さ */
-const DESCRIPTION_LENGTH = 120;
+/** カードに出す本文（箇条書きの前）の長さ */
+const SUMMARY_LENGTH = 100;
 
 function formatDate(iso: string): string {
 	const date = new Date(iso);
@@ -45,21 +53,52 @@ function formatDate(iso: string): string {
 	return `${yyyy}-${mm}-${dd}`;
 }
 
-/**
- * Issue 本文はマークダウンなので、記号を落としてカード用の一文にする。
- * 見出しやリストの記号がそのまま出ると読めないため。
- */
-function toDescription(body: string | null): string {
-	if (!body) return "";
-	const plain = body
-		.replace(/```[\s\S]*?```/g, "") // コードブロックごと落とす
-		.replace(/^#+\s*/gm, "")
-		.replace(/^[-*]\s*/gm, "")
+/** 装飾のマークダウン記号を落として、そのまま出せるテキストにする */
+function toPlainText(line: string): string {
+	return line
 		.replace(/!?\[([^\]]*)\]\([^)]*\)/g, "$1") // リンク・画像はテキストだけ残す
 		.replace(/[*_`>|]/g, "")
 		.replace(/\s+/g, " ")
 		.trim();
-	return plain.length > DESCRIPTION_LENGTH ? `${plain.slice(0, DESCRIPTION_LENGTH)}…` : plain;
+}
+
+/**
+ * Issue 本文を「文」と「箇条書き」に分けて読む。
+ * 箇条書きを1本の文につなげると `[x]` や中黒が文中に紛れて読めなくなるので、
+ * カード側でリストとして組めるよう、構造を保ったまま渡す。
+ *
+ * 箇条書きより後ろの段落は落とす。カードに収まる量を超えるうえ、
+ * 続きは Issue を開けば読めるため。
+ */
+function parseBody(body: string | null): { summary: string; items: RoadmapListItem[] } {
+	if (!body) return { summary: "", items: [] };
+
+	const lines = body.replace(/```[\s\S]*?```/g, "").split(/\r?\n/); // コードブロックごと落とす
+	const summaryLines: string[] = [];
+	const items: RoadmapListItem[] = [];
+
+	for (const raw of lines) {
+		const line = raw.trim();
+		if (!line) continue;
+		if (/^#{1,6}\s/.test(line)) continue; // 見出しはカードでは使わない
+
+		const list = line.match(/^(?:[-*+]|\d+\.)\s+(.*)$/);
+		if (list) {
+			const checkbox = list[1].match(/^\[([ xX])\]\s*(.*)$/);
+			const text = toPlainText(checkbox ? checkbox[2] : list[1]);
+			if (!text) continue; // 「- 」だけの空行は捨てる
+			items.push(checkbox ? { text, done: checkbox[1].toLowerCase() === "x" } : { text });
+			continue;
+		}
+
+		if (items.length === 0) summaryLines.push(toPlainText(line));
+	}
+
+	const summary = summaryLines.join(" ");
+	return {
+		summary: summary.length > SUMMARY_LENGTH ? `${summary.slice(0, SUMMARY_LENGTH)}…` : summary,
+		items,
+	};
 }
 
 /**
@@ -96,7 +135,7 @@ export async function getRoadmapItems(): Promise<RoadmapItem[]> {
 			.map((issue) => ({
 				number: issue.number,
 				title: issue.title,
-				description: toDescription(issue.body),
+				...parseBody(issue.body),
 				status: toStatus(issue),
 				url: issue.html_url,
 				createdAt: formatDate(issue.created_at),


### PR DESCRIPTION
## やったこと

これから盛り込みたい機能を、GitHub の Issue そのままをネタ元にして `/roadmap` で公開しました。close #42

サイト側にロードマップの一覧を別に持つと Issue と二重管理になってずれるので、公開する内容は `enhancement` ラベルの Issue に一本化しています。

### 状態の振り分け

| Issue の状態 | 表示 |
|---|---|
| closed | できた |
| open + 担当者あり | いま作ってる |
| open | 作りたい |

「いま作ってる」の判定は**アサイン**です。着手を表す情報が Issue に他になかったためで、自分をアサインするとサイト上で上に上がります。別の合図にしたくなったら `src/lib/roadmap.ts` の `toStatus` を差し替えるだけです。

### 見た目

3つの節を1本の破線でつないで、上から下へ進む道に見せています。冒頭に「できたこと N / M」の進捗バー（0から伸びる）。

カードは状態で作りを変えていて、**作りたい**＝破線、**いま作ってる**＝実線＋脈打つ点、**できた**＝チェック＋少し落とした表示。色だけに頼っていないのは、時間帯で背景色が変わっても区別がつくようにするためです（#35 の作りに合わせています）。カード全体が Issue へのリンクです。

節ごとに `/roadmap#wip` `#todo` `#done` で直接リンクできます。

### 導線

トップページのブログの下に節を追加し、「いま作ってる」＋「作りたい」から3件と `/roadmap` へのリンクを置きました。グローバルナビは、モバイルで5項目になって窮屈になるため触っていません。

## GITHUB_TOKEN について

未認証だと GitHub API は IP あたり 60req/h で、ホスティングの送信元 IP は他のテナントと共有されます（開発中に実際に踏みました）。`GITHUB_TOKEN` があれば使う作りにしてあり、`.env.local` と Vercel の環境変数に設定済みです。無くても動きますが、その場合はレート制限に当たると空表示になります。

取得は `per_page=100` で1リクエスト、ISR で1時間キャッシュなので本番は最大24req/日です。enhancement が100件を超えたらページングの追加が要ります。

取得に失敗してもページごと落とさず、空の状態で表示します。

## 検算

- 実データで `/roadmap` とトップを表示（1280px / 390px の両方）。カードのリンク先が正しい Issue に向くこと、進捗バーが 1/5 = 20% で伸びることを確認
- 「いま作ってる」は現在アサイン済みの Issue がないため空。一時的に1件を wip に倒してカードの見た目も確認済み（その変更は入れていません）
- トークン設定の前後で未認証枠の消費を比較し、認証済みで飛んでいることを確認（4回描画で +3 → ±0）
- コンソールエラーなし、biome・tsc ともにクリーン
- Storybook に RoadmapCard（3状態）と RoadmapProgress のストーリーを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)